### PR TITLE
Patch plugin to use local execution by default for test debugging

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
@@ -39,6 +39,9 @@ public final class BlazeFlags {
   // It expands to: --test_arg=--wrapper_script_flag=--debug --test_output=streamed
   //   --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
   public static final String JAVA_TEST_DEBUG = "--java_debug";
+  // Debugging tests should only run locally, so make sure no remote executor is defined
+  // while debugging tests
+  public static final String RUN_LOCALLY = "--remote_executor=";
   // Streams stdout/stderr output from each test in real-time.
   // Implies --test_strategy=exclusive and --test_sharding_strategy=disabled
   public static final String TEST_OUTPUT_STREAMED = "--test_output=streamed";

--- a/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
+++ b/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
@@ -272,6 +272,7 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
         command.addExeFlags(debugPortFlag(false, debugPort));
       } else {
         command.addBlazeFlags(BlazeFlags.JAVA_TEST_DEBUG);
+        command.addBlazeFlags(BlazeFlags.RUN_LOCALLY);
         command.addBlazeFlags(debugPortFlag(true, debugPort));
       }
       if (kotlinxCoroutinesJavaAgent != null) {

--- a/java/tests/unittests/com/google/idea/blaze/java/run/BlazeJavaRunProfileStateTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/run/BlazeJavaRunProfileStateTest.java
@@ -233,6 +233,7 @@ public class BlazeJavaRunProfileStateTest extends BlazeTestCase {
                 "command",
                 BlazeFlags.getToolTagFlag(),
                 "--java_debug",
+                "--remote_executor=",
                 "--test_arg=--wrapper_script_flag=--debug=127.0.0.1:5005",
                 "--",
                 "//label:rule"));
@@ -260,6 +261,7 @@ public class BlazeJavaRunProfileStateTest extends BlazeTestCase {
               "test",
               BlazeFlags.getToolTagFlag(),
               "--java_debug",
+              "--remote_executor=",
               "--test_arg=--wrapper_script_flag=--debug=127.0.0.1:5005",
               "--",
               "//label:java_test_suite_rule"));


### PR DESCRIPTION
Patch to re-allow test debugging by having tests run locally by default.